### PR TITLE
Feature/surgical

### DIFF
--- a/Intake.xcodeproj/project.pbxproj
+++ b/Intake.xcodeproj/project.pbxproj
@@ -108,6 +108,7 @@
 		F42AB1E52B6383F9002E13A6 /* LLMOpenAITokenOnboarding.swift in Sources */ = {isa = PBXBuildFile; fileRef = F42AB1E42B6383F9002E13A6 /* LLMOpenAITokenOnboarding.swift */; };
 		F42AB1EC2B6DBF21002E13A6 /* SummaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F42AB1EB2B6DBF20002E13A6 /* SummaryView.swift */; };
 		F42AB1F22B71B4D2002E13A6 /* AllergyViewTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F42AB1F12B71B4D0002E13A6 /* AllergyViewTest.swift */; };
+		F4F4F8812B8C6FC5008FBEED /* Elements.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4F4F8802B8C6FC5008FBEED /* Elements.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -203,6 +204,7 @@
 		F42AB1E42B6383F9002E13A6 /* LLMOpenAITokenOnboarding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LLMOpenAITokenOnboarding.swift; sourceTree = "<group>"; };
 		F42AB1EB2B6DBF20002E13A6 /* SummaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryView.swift; sourceTree = "<group>"; };
 		F42AB1F12B71B4D0002E13A6 /* AllergyViewTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllergyViewTest.swift; sourceTree = "<group>"; };
+		F4F4F8802B8C6FC5008FBEED /* Elements.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Elements.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -449,6 +451,7 @@
 		653A254F283387FE005D4D48 /* Intake */ = {
 			isa = PBXGroup;
 			children = (
+				F4F4F8802B8C6FC5008FBEED /* Elements.swift */,
 				511827972B7401A8002033A0 /* MedicationView.swift */,
 				511827942B740191002033A0 /* Surgery */,
 				AC2A17272B70684D00F560D0 /* SocialHistory */,
@@ -508,6 +511,14 @@
 			path = Account;
 			sourceTree = "<group>";
 		};
+		AC2A17272B70684D00F560D0 /* SocialHistory */ = {
+			isa = PBXGroup;
+			children = (
+				AC2A17282B70686000F560D0 /* SocialHistoryQuestions.swift */,
+			);
+			path = SocialHistory;
+			sourceTree = "<group>";
+		};
 		F42AB1DA2B637C5F002E13A6 /* ChiefComplaint */ = {
 			isa = PBXGroup;
 			children = (
@@ -526,14 +537,6 @@
 				F42AB1E42B6383F9002E13A6 /* LLMOpenAITokenOnboarding.swift */,
 			);
 			path = OpenAI;
-			sourceTree = "<group>";
-		};
-		AC2A17272B70684D00F560D0 /* SocialHistory */ = {
-			isa = PBXGroup;
-			children = (
-				AC2A17282B70686000F560D0 /* SocialHistoryQuestions.swift */,
-			);
-			path = SocialHistory;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -790,6 +793,7 @@
 				5A2B9F872B69E06B005CA63F /* ResourceSelection.swift in Sources */,
 				2F4E23832989D51F0013F3D9 /* IntakeTestingSetup.swift in Sources */,
 				5A2B9F862B69E06B005CA63F /* SettingsView.swift in Sources */,
+				F4F4F8812B8C6FC5008FBEED /* Elements.swift in Sources */,
 				2FE5DC5329EDD7FA004B9AB4 /* Bundle+Questionnaire.swift in Sources */,
 				5A2B9FB62B6AFE5D005CA63F /* AllergyRecords.swift in Sources */,
 				2FE5DC5129EDD7FA004B9AB4 /* IntakeTaskContext.swift in Sources */,

--- a/Intake.xcodeproj/xcshareddata/xcschemes/Intake.xcscheme
+++ b/Intake.xcodeproj/xcshareddata/xcschemes/Intake.xcscheme
@@ -79,15 +79,15 @@
       <CommandLineArguments>
          <CommandLineArgument
             argument = "--disableFirebase"
-            isEnabled = "NO">
-         </CommandLineArgument>
-         <CommandLineArgument
-            argument = "--showOnboarding"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "--skipOnboarding"
+            argument = "--showOnboarding"
             isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "--skipOnboarding"
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--testSchedule"
@@ -95,7 +95,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--useFirebaseEmulator"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
       </CommandLineArguments>
    </LaunchAction>

--- a/Intake/ChiefComplaint/LLMInteraction.swift
+++ b/Intake/ChiefComplaint/LLMInteraction.swift
@@ -17,6 +17,22 @@ import SpeziLLMLocal
 import SpeziLLMOpenAI
 import SwiftUI
 
+struct SkipButton: View {
+    var action: () -> Void
+    
+    var body: some View {
+        Button(action: action) {
+            Text("Skip")
+                .font(.headline)
+                .foregroundColor(.blue)
+                .padding(8) // Add padding for better appearance
+                .background(Color.white) // Set background color to white
+                .cornerRadius(8) // Round the corners
+        }
+        .buttonStyle(PlainButtonStyle()) // Remove button border
+    }
+}
+
 struct LLMInteraction: View {
     @Observable
     class StringBox: Equatable {
@@ -31,14 +47,12 @@ struct LLMInteraction: View {
         }
     }
     
-
     struct SummarizeFunction: LLMFunction {
         static let name: String = "summarize_complaint"
         static let description: String = """
                     When there is enough information to give to the doctor,\
                     summarize the conversation into a concise Chief Complaint.
                     """
-
         
         @Parameter(description: "A summary of the patient's primary concern.") var patientSummary: String
         
@@ -67,14 +81,14 @@ struct LLMInteraction: View {
     
     var body: some View {
         LLMChatView(
-            model: model
+            model: model,
+            exportFormat: .nil
         )
         .navigationTitle("Chief Complaint")
-        .toolbar {  // Is this doing anything except causing problems?
-            if AccountButton.shouldDisplay {
-                AccountButton(isPresented: $presentingAccount)
-            }
-        }
+        .navigationBarItems(trailing: SkipButton {
+            self.showSheet = true
+        })
+        
         .sheet(isPresented: $showOnboarding) {
             LLMOnboardingView(showOnboarding: $showOnboarding)
         }

--- a/Intake/ChiefComplaint/LLMInteraction.swift
+++ b/Intake/ChiefComplaint/LLMInteraction.swift
@@ -82,7 +82,7 @@ struct LLMInteraction: View {
     var body: some View {
         LLMChatView(
             model: model,
-            exportFormat: .nil
+//            exportFormat: .nil
         )
         .navigationTitle("Chief Complaint")
         .navigationBarItems(trailing: SkipButton {

--- a/Intake/ChiefComplaint/LLMInteraction.swift
+++ b/Intake/ChiefComplaint/LLMInteraction.swift
@@ -82,7 +82,6 @@ struct LLMInteraction: View {
     var body: some View {
         LLMChatView(
             model: model
-//            exportFormat: .nil
         )
         .navigationTitle("Chief Complaint")
         .navigationBarItems(trailing: SkipButton {

--- a/Intake/ChiefComplaint/LLMInteraction.swift
+++ b/Intake/ChiefComplaint/LLMInteraction.swift
@@ -81,7 +81,7 @@ struct LLMInteraction: View {
     
     var body: some View {
         LLMChatView(
-            model: model,
+            model: model
 //            exportFormat: .nil
         )
         .navigationTitle("Chief Complaint")

--- a/Intake/Elements.swift
+++ b/Intake/Elements.swift
@@ -1,0 +1,34 @@
+//
+//  Elements.swift
+//  Intake
+//
+//  Created by Nick Riedman on 2/25/24.
+//
+// This source file is part of the Intake based on the Stanford Spezi Template Application project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SwiftUI
+
+struct SubmitButton: View {
+    @EnvironmentObject private var navigationPath: NavigationPathWrapper
+    var nextView: NavigationViews
+    
+    var body: some View {
+        Button(action: {
+            // Save output to Firestore and navigate to next screen
+            // Still need to save output to Firestore
+            self.navigationPath.append_item(item: nextView)
+        }) {
+            Text("Submit")
+                .foregroundColor(.white)
+                .padding()
+                .frame(maxWidth: .infinity)
+                .background(Color.blue)
+                .cornerRadius(8)
+        }
+    }
+}

--- a/Intake/Resources/Localizable.xcstrings
+++ b/Intake/Resources/Localizable.xcstrings
@@ -174,6 +174,9 @@
         }
       }
     },
+    "Date" : {
+
+    },
     "DELETE_ALLERGY" : {
 
     },
@@ -184,9 +187,6 @@
 
     },
     "DELETE_REACTION" : {
-
-    },
-    "DELETE_SURGERY" : {
 
     },
     "Do you currently smoke or have you in the past?" : {
@@ -430,9 +430,6 @@
     "Please list your current medications." : {
 
     },
-    "Please list your previous surgeries." : {
-
-    },
     "Primary Concern" : {
 
     },
@@ -647,6 +644,9 @@
 
     },
     "What brings you in today? Identify your primary concern(s)." : {
+
+    },
+    "What is your surgical history?" : {
 
     },
     "You can include decimal values (e.g., 0.25) for the number of packs per day." : {

--- a/Intake/Resources/Localizable.xcstrings
+++ b/Intake/Resources/Localizable.xcstrings
@@ -540,6 +540,9 @@
     "Share with provider of your choice." : {
 
     },
+    "Skip" : {
+
+    },
     "Social History" : {
 
     },

--- a/Intake/Resources/Localizable.xcstrings
+++ b/Intake/Resources/Localizable.xcstrings
@@ -174,9 +174,6 @@
         }
       }
     },
-    "Date" : {
-
-    },
     "DELETE_ALLERGY" : {
 
     },

--- a/Intake/Surgery/SurgeryView.swift
+++ b/Intake/Surgery/SurgeryView.swift
@@ -18,12 +18,12 @@ import SwiftUI
 struct SurgeryItem: Identifiable {
     var id = UUID()
     var surgeryName: String = ""
-    var date: String = ""
-//    var location: String
-//    var complications: String
-//    var notes: String
-//    var status: String
-//    var code: String
+    var date: String?
+//    var location: String?
+//    var complications: String?
+//    var notes: String?
+//    var status: String?
+//    var code: String?
 }
 
 struct AddSurgeryButton: View {
@@ -49,16 +49,26 @@ struct InspectSurgeryView: View {
     
     var body: some View {
         List {
-            Section(header: Text("Date")) {
+            Section(header: Text("Surgery")) {
                 if editMode?.wrappedValue.isEditing == true {
-                    TextField("Date", text: $surgery.date)
+                    TextField("Surgery", text: $surgery.surgeryName)
                 } else {
-                    Text(surgery.date)
+                    Text(surgery.surgeryName)
                 }
             }
+//            if let date = surgery.date {
+//                @Bindable var date = date
+//                
+//                Section(header: Text("Date")) {
+//                    if editMode?.wrappedValue.isEditing == true {
+//                        TextField("Date", text: $date)
+//                    } else {
+//                        Text(date)
+//                    }
+//                }
+//            }
         }
         .listStyle(.grouped)
-        .navigationTitle(surgery.surgeryName)
         .toolbar {
             EditButton()
         }

--- a/Intake/Surgery/SurgeryView.swift
+++ b/Intake/Surgery/SurgeryView.swift
@@ -59,6 +59,7 @@ struct SurgeryView: View {
                     }
                     .navigationBarTitleDisplayMode(.inline)
                     .toolbar {
+//                        EditButton()
                         ToolbarItem(placement: .principal) {
                             Text("Please list your previous surgeries.")
                                 .font(.system(size: 28)) // Choose a size that fits

--- a/Intake/Surgery/SurgeryView.swift
+++ b/Intake/Surgery/SurgeryView.swift
@@ -17,77 +17,113 @@ import SwiftUI
 
 struct SurgeryItem: Identifiable {
     var id = UUID()
-    var surgeryName: String
+    var surgeryName: String = ""
+    var date: String = ""
+//    var location: String
+//    var complications: String
+//    var notes: String
+//    var status: String
+//    var code: String
 }
 
+struct AddSurgeryButton: View {
+    @Binding var surgeries: [SurgeryItem]
+    
+    var body: some View {
+        Button(action: {
+            // Action to add new item
+            surgeries.append(SurgeryItem(surgeryName: "", date: ""))
+        }) {
+            HStack {
+                Image(systemName: "plus.circle.fill")
+                    .accessibilityLabel(Text("ADD_SURGERY"))
+                Text("Add Field")
+            }
+        }
+    }
+}
+
+struct InspectSurgeryView: View {
+    @Environment(\.editMode) private var editMode
+    @Binding var surgery: SurgeryItem
+    
+    var body: some View {
+        List {
+            Section(header: Text("Date")) {
+                if editMode?.wrappedValue.isEditing == true {
+                    TextField("Date", text: $surgery.date)
+                } else {
+                    Text(surgery.date)
+                }
+            }
+        }
+        .listStyle(.grouped)
+        .navigationTitle(surgery.surgeryName)
+        .toolbar {
+            EditButton()
+        }
+    }
+}
 
 struct SurgeryView: View {
     @Environment(FHIRStore.self) private var fhirStore
+    @Environment(\.editMode) private var editMode
     @EnvironmentObject private var navigationPath: NavigationPathWrapper
     @State private var surgeries: [SurgeryItem] = []
 
-        var body: some View {
-            NavigationView { // swiftlint:disable:this closure_body_length
-                VStack { // swiftlint:disable:this closure_body_length
-                    List {
-                        ForEach($surgeries) { $item in
-                            HStack {
-                                TextField("Surgery", text: $item.surgeryName)
-                                Button(action: {
-                                    // Action to delete this item
-                                    if let index = surgeries.firstIndex(where: { $0.id == item.id }) {
-                                        surgeries.remove(at: index)
-                                    }
-                                }) {
-                                    Image(systemName: "xmark.circle")
-                                        .accessibilityLabel(Text("DELETE_SURGERY"))
-                                }
-                            }
-                        }
-                        .onDelete(perform: delete)
-                        
-                        Button(action: {
-                            // Action to add new item
-                            surgeries.append(SurgeryItem(surgeryName: ""))
-                        }) {
-                            HStack {
-                                Image(systemName: "plus.circle.fill")
-                                    .accessibilityLabel(Text("ADD_SURGERY"))
-                                Text("Add Field")
+    var body: some View {
+        VStack {
+            List {
+                Section(header: Text("What is your surgical history?")) {
+                    // Extension: Sort these by date
+                    ForEach($surgeries) { $item in
+                        if editMode?.wrappedValue.isEditing == true {
+                            TextField("Surgery", text: $item.surgeryName)
+                        } else {
+                            NavigationLink(destination: InspectSurgeryView(surgery: $item)) {
+                                Label(item.surgeryName, systemImage: "arrowtriangle.right")
+                                    .labelStyle(.titleOnly)
                             }
                         }
                     }
-                    .navigationBarTitleDisplayMode(.inline)
-                    .toolbar {
-//                        EditButton()
-                        ToolbarItem(placement: .principal) {
-                            Text("Please list your previous surgeries.")
-                                .font(.system(size: 28)) // Choose a size that fits
-                                .lineLimit(1)
-                                .minimumScaleFactor(0.5) // Adjusts the font size to fit the width of the line
-                        }
+                    .onDelete(perform: delete)
+                    if editMode?.wrappedValue.isEditing == true {
+                        AddSurgeryButton(surgeries: $surgeries)
                     }
-                    Button(action: {
-                        // Save output to Firestore and navigate to next screen
-                        // Still need to save output to Firestore
-                        self.navigationPath.append_item(item: NavigationViews.medication)
-                    }) {
-                        Text("Submit")
-                            .foregroundColor(.white)
-                            .padding()
-                            .frame(maxWidth: .infinity)
-                            .background(Color.blue)
-                            .cornerRadius(8)
-                    }
-                    .padding()
                 }
             }
-            }
+            SubmitButton(nextView: NavigationViews.medication)
+            .padding()
+        }
         
-        func delete(at offsets: IndexSet) {
-            surgeries.remove(atOffsets: offsets)
+        .onAppear {
+            self.getProcedures()
+        }
+        .navigationTitle("Surgical History")
+        .toolbar {
+            EditButton()
         }
     }
+
+    func delete(at offsets: IndexSet) {
+        surgeries.remove(atOffsets: offsets)
+    }
+    
+    func getProcedures() {
+        let procedures = fhirStore.procedures
+//      print(procedures)
+        
+        for pro in procedures where !self.surgeries.contains(where: { $0.surgeryName == pro.displayName }) {
+            var newEntry = SurgeryItem(surgeryName: pro.displayName)
+            
+            if let date = pro.date?.formatted() {
+                newEntry.date = date
+            }
+            
+            self.surgeries.append(newEntry)
+        }
+    }
+}
         
 
 #Preview {


### PR DESCRIPTION
# Surgical History UI Overhaul

## :recycle: Current situation & Problem
The Surgical History view was not developed whatsoever. The UI was the default, pre-demo UI with no backend.


## :gear: Release Notes 
Added a backend that reads in the patient's procedures from FHIRStore.
Displayed each procedure in a List, where each element is a NavigationLink to a detailed view with information such as date, complications, notes, location, etc. The label of these lists is the name of the procedure.
On the backend, created Elements.swift to store reusable UI components such as the submit button.
Also added a Skip Button to the Chief Complaint view.

## :books: Documentation
NA

## :white_check_mark: Testing
NA

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).
