### PR TITLE
Feature/export surgical history

### DIFF
--- a/Intake/ChiefComplaint/LLMInteraction.swift
+++ b/Intake/ChiefComplaint/LLMInteraction.swift
@@ -64,10 +64,6 @@ struct LLMInteraction: View {
     @State var greeting = true
     @State var stringBox: StringBox = .init()
     
-    private func showSummary() {
-        navigationPath.path.append(NavigationViews.concern)
-    }
-    
     var body: some View {
         @Bindable var data = data
         
@@ -150,6 +146,10 @@ struct LLMInteraction: View {
                 SummarizeFunction(stringBox: temporaryStringBox)
             }
         )
+    }
+    
+    private func showSummary() {
+        navigationPath.path.append(NavigationViews.concern)
     }
 }
 

--- a/Intake/ChiefComplaint/SummaryView.swift
+++ b/Intake/ChiefComplaint/SummaryView.swift
@@ -14,50 +14,28 @@
 import Foundation
 import SwiftUI
 
-struct SummaryView: View {
-    @State var chiefComplaint: String
-    @Binding var isPresented: Bool
+struct ComplaintForm: View {
+    @Binding var chiefComplaint: String
+    
+    var body: some View {
+        Form {
+            Section(header: Text("Here is a summary of the Primary Concern")) {
+                TextField("Primary Concern", text: $chiefComplaint, axis: .vertical)
+            }
+        }
+        .navigationTitle("Primary Concern")
+    }
+}
 
+struct SummaryView: View {
+    @Binding var chiefComplaint: String
     @Environment(NavigationPathWrapper.self) private var navigationPath
 
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {
-            Text("Primary Concern")
-                .font(.title)
-                .padding(.top, 50)
-
-            Text("Here is a summary of your primary concern:")
-
-            TextEditor(text: $chiefComplaint)
-                .frame(height: 150)
-                .background(Color.white)
-                .cornerRadius(8)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 8)
-                        .stroke(Color.secondary, lineWidth: 1)
-                )
-                .padding(.horizontal)
-
-            Button(action: {
-                // Save output to Firestore and navigate to next screen
-                // Still need to save output to Firestore
-                navigationPath.path.append(NavigationViews.medical)
-                self.isPresented.toggle()
-            }) {
-                Text("Submit")
-                    .foregroundColor(.white)
-                    .padding()
-                    .frame(maxWidth: .infinity)
-                    .background(Color.blue)
-                    .cornerRadius(8)
-            }
-            .padding(.horizontal)
+            ComplaintForm(chiefComplaint: $chiefComplaint)
+            SubmitButton(nextView: NavigationViews.medical)
+                .padding()
         }
-        .padding()
-    }
-
-    init(chiefComplaint: String, isPresented: Binding<Bool>) {
-        self.chiefComplaint = chiefComplaint
-        self._isPresented = isPresented
     }
 }

--- a/Intake/Elements.swift
+++ b/Intake/Elements.swift
@@ -13,6 +13,23 @@
 
 import SwiftUI
 
+struct SkipButton: View {
+    var action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text("Skip")
+                .font(.headline)
+                .foregroundColor(.blue)
+                .padding(8) // Add padding for better appearance
+                .background(Color.white) // Set background color to white
+                .cornerRadius(8) // Round the corners
+        }
+        .buttonStyle(PlainButtonStyle()) // Remove button border
+    }
+}
+
+
 struct SubmitButton: View {
     @Environment(NavigationPathWrapper.self) private var navigationPath
     var nextView: NavigationViews

--- a/Intake/Elements.swift
+++ b/Intake/Elements.swift
@@ -39,7 +39,7 @@ struct SubmitButton: View {
             // Still need to save output to Firestore
             navigationPath.path.append(nextView)
         }) {
-            Text("Submit")
+            Text("Next")
                 .foregroundColor(.white)
                 .padding()
                 .frame(maxWidth: .infinity)

--- a/Intake/Elements.swift
+++ b/Intake/Elements.swift
@@ -22,7 +22,6 @@ struct SkipButton: View {
                 .font(.headline)
                 .foregroundColor(.blue)
                 .padding(8) // Add padding for better appearance
-                .background(Color.white) // Set background color to white
                 .cornerRadius(8) // Round the corners
         }
         .buttonStyle(PlainButtonStyle()) // Remove button border

--- a/Intake/Home.swift
+++ b/Intake/Home.swift
@@ -17,6 +17,7 @@ enum NavigationViews: String {
     case social
     case medication
     case chat
+    case concern
 }
 
 struct HomeView: View {
@@ -28,9 +29,12 @@ struct HomeView: View {
     @State private var showSettings = false
 
     @Environment(NavigationPathWrapper.self) private var navigationPath
+    @Environment(DataStore.self) private var data
 
     var body: some View {
         @Bindable var navigationPath = navigationPath
+        @Bindable var data = data
+        
         NavigationStack(path: $navigationPath.path) { // swiftlint:disable:this closure_body_length
             VStack { // swiftlint:disable:this closure_body_length
                 HStack {
@@ -90,6 +94,7 @@ struct HomeView: View {
                 case .medical: MedicalHistoryView()
                 case .social: SocialHistoryQuestionView()
                 case .medication: MedicationView()
+                case .concern: SummaryView(chiefComplaint: $data.chiefComplaint)
                 }
             }
         }

--- a/Intake/Intake.swift
+++ b/Intake/Intake.swift
@@ -20,6 +20,8 @@ class DataStore {
     var allergyData: [AllergyItem] = []
     var conditionData: [MedicalHistoryItem] = []
     var medicationData: [MedicationItem] = []
+    var surgeries: [SurgeryItem] = []
+    var chiefComplaint: String = ""
 }
 
 @main

--- a/Intake/Resources/Localizable.xcstrings
+++ b/Intake/Resources/Localizable.xcstrings
@@ -360,6 +360,9 @@
         }
       }
     },
+    "Next" : {
+
+    },
     "Next: Smoking History" : {
 
     },
@@ -565,6 +568,9 @@
 
     },
     "Surgery" : {
+
+    },
+    "Surgery Name" : {
 
     },
     "Surgical History" : {

--- a/Intake/Resources/Localizable.xcstrings
+++ b/Intake/Resources/Localizable.xcstrings
@@ -91,9 +91,6 @@
     "Auto-fill Intake Form" : {
 
     },
-    "Chief Complaint" : {
-
-    },
     "CLOSE" : {
       "comment" : "MARK: General",
       "localizations" : {
@@ -245,7 +242,7 @@
         }
       }
     },
-    "Here is a summary of your primary concern:" : {
+    "Here is a summary of the Primary Concern" : {
 
     },
     "HOME_LOGO" : {

--- a/Intake/Surgery/SurgeryView.swift
+++ b/Intake/Surgery/SurgeryView.swift
@@ -17,7 +17,7 @@ import SwiftUI
 
 struct SurgeryItem: Identifiable {
     var id = UUID()
-    var surgeryName: String = ""
+    var surgeryName: String
     var date: String?
 //    var location: String?
 //    var complications: String?
@@ -32,7 +32,7 @@ struct AddSurgeryButton: View {
     var body: some View {
         Button(action: {
             // Action to add new item
-            surgeries.append(SurgeryItem(surgeryName: "", date: ""))
+            surgeries.append(SurgeryItem(surgeryName: "Surgery", date: ""))
         }) {
             HStack {
                 Image(systemName: "plus.circle.fill")
@@ -44,17 +44,12 @@ struct AddSurgeryButton: View {
 }
 
 struct InspectSurgeryView: View {
-    @Environment(\.editMode) private var editMode
     @Binding var surgery: SurgeryItem
     
     var body: some View {
-        List {
+        Form {
             Section(header: Text("Surgery")) {
-                if editMode?.wrappedValue.isEditing == true {
-                    TextField("Surgery", text: $surgery.surgeryName)
-                } else {
-                    Text(surgery.surgeryName)
-                }
+                TextField("Surgery Name", text: $surgery.surgeryName)
             }
 //            if let date = surgery.date {
 //                @Bindable var date = date
@@ -75,43 +70,69 @@ struct InspectSurgeryView: View {
     }
 }
 
+
+/*
+ List {
+     Section(header: Text("What is your surgical history?")) {
+         // Extension: Sort these by date
+         ForEach($data.surgeries) { $item in
+             if editMode?.wrappedValue.isEditing == true {
+                 TextField("Surgery", text: $item.surgeryName)
+             } else {
+                 NavigationLink(destination: InspectSurgeryView(surgery: $item)) {
+                     Label(item.surgeryName, systemImage: "arrowtriangle.right")
+                         .labelStyle(.titleOnly)
+                 }
+             }
+         }
+         .onDelete(perform: delete)
+         if editMode?.wrappedValue.isEditing == true {
+             AddSurgeryButton(surgeries: $data.surgeries)
+         }
+     }
+ }
+ */
+
 struct SurgeryView: View {
     @Environment(FHIRStore.self) private var fhirStore
     @Environment(DataStore.self) private var data
     @Environment(\.editMode) private var editMode
 
     var body: some View {
-        @Bindable var data = data
         VStack {
-            List {
-                Section(header: Text("What is your surgical history?")) {
-                    // Extension: Sort these by date
-                    ForEach($data.surgeries) { $item in
-                        if editMode?.wrappedValue.isEditing == true {
-                            TextField("Surgery", text: $item.surgeryName)
-                        } else {
-                            NavigationLink(destination: InspectSurgeryView(surgery: $item)) {
-                                Label(item.surgeryName, systemImage: "arrowtriangle.right")
-                                    .labelStyle(.titleOnly)
-                            }
-                        }
-                    }
-                    .onDelete(perform: delete)
-                    if editMode?.wrappedValue.isEditing == true {
-                        AddSurgeryButton(surgeries: $data.surgeries)
-                    }
-                }
-            }
+            surgeryForm
             SubmitButton(nextView: NavigationViews.medication)
             .padding()
         }
-
         .onAppear {
             self.getProcedures()
         }
         .navigationTitle("Surgical History")
         .toolbar {
             EditButton()
+        }
+    }
+    
+    private var surgeryElements: some View {
+        Group {
+            @Bindable var data = data
+            ForEach($data.surgeries) { $item in
+                NavigationLink(destination: InspectSurgeryView(surgery: $item)) {
+                    Label(item.surgeryName, systemImage: "arrowtriangle.right")
+                        .labelStyle(.titleOnly)
+                }
+            }
+            .onDelete(perform: delete)
+        }
+    }
+    
+    private var surgeryForm: some View {
+        Form {
+            @Bindable var data = data
+            Section(header: Text("What is your surgical history?")) {
+                surgeryElements
+                AddSurgeryButton(surgeries: $data.surgeries)
+            }
         }
     }
 

--- a/Intake/Surgery/SurgeryView.swift
+++ b/Intake/Surgery/SurgeryView.swift
@@ -46,7 +46,7 @@ struct AddSurgeryButton: View {
 struct InspectSurgeryView: View {
     @Environment(\.editMode) private var editMode
     @Binding var surgery: SurgeryItem
-
+    
     var body: some View {
         List {
             Section(header: Text("Surgery")) {
@@ -77,16 +77,16 @@ struct InspectSurgeryView: View {
 
 struct SurgeryView: View {
     @Environment(FHIRStore.self) private var fhirStore
+    @Environment(DataStore.self) private var data
     @Environment(\.editMode) private var editMode
-    @Environment(NavigationPathWrapper.self) private var navigationPath
-    @State private var surgeries: [SurgeryItem] = []
 
     var body: some View {
+        @Bindable var data = data
         VStack {
             List {
                 Section(header: Text("What is your surgical history?")) {
                     // Extension: Sort these by date
-                    ForEach($surgeries) { $item in
+                    ForEach($data.surgeries) { $item in
                         if editMode?.wrappedValue.isEditing == true {
                             TextField("Surgery", text: $item.surgeryName)
                         } else {
@@ -98,7 +98,7 @@ struct SurgeryView: View {
                     }
                     .onDelete(perform: delete)
                     if editMode?.wrappedValue.isEditing == true {
-                        AddSurgeryButton(surgeries: $surgeries)
+                        AddSurgeryButton(surgeries: $data.surgeries)
                     }
                 }
             }
@@ -116,21 +116,21 @@ struct SurgeryView: View {
     }
 
     func delete(at offsets: IndexSet) {
-        surgeries.remove(atOffsets: offsets)
+        data.surgeries.remove(atOffsets: offsets)
     }
 
     func getProcedures() {
         let procedures = fhirStore.procedures
 //      print(procedures)
 
-        for pro in procedures where !self.surgeries.contains(where: { $0.surgeryName == pro.displayName }) {
+        for pro in procedures where !data.surgeries.contains(where: { $0.surgeryName == pro.displayName }) {
             var newEntry = SurgeryItem(surgeryName: pro.displayName)
 
             if let date = pro.date?.formatted() {
                 newEntry.date = date
             }
 
-            self.surgeries.append(newEntry)
+            data.surgeries.append(newEntry)
         }
     }
 }


### PR DESCRIPTION
# Integrate DataStore into Surgical History and ChiefComplaint

## :recycle: Current situation & Problem
Surgical History and Chief Complaint currently store their results in local variables that do not persist. We need to instead store their outputs in the DataStore environment variable.


## :gear: Release Notes 
Surgical History now stores its results in the DataStore.surgeries parameter as an array of SurgeryItems. ChiefComplaint now stores its results in the DataStore.chiefComplaint field as a String.


## :books: Documentation
Access the information as follows:
```swift
struct TestView: View {
     @Environment(DataStore.self) private var data

     var body: some View {
           \\\ Often need to pass bindings to elements of the data, and can do so with this declaration
          @Bindable var data = data
          var surgeries: [SurgeryItem] = data.surgeries
          var chiefComplaint: String = data.chiefComplaint
     }
}
``` 


## :white_check_mark: Testing
NA


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).
