### PR TITLE
Finalize/surgery_home

### DIFF
--- a/Intake.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Intake.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "cdbe60a3382a8a962c7fcc00210e56e13314cb3e246d0e01fe8e25a1268623d8",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -149,8 +150,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordBDHG/ResearchKit",
       "state" : {
-        "revision" : "e4afb10ec636a70e06afc4a84fb98e457818439a",
-        "version" : "2.2.27"
+        "revision" : "64512d0a0a5cc3e9d5b3fc5217c54f11d0dc044c",
+        "version" : "2.2.28"
       }
     },
     {
@@ -275,8 +276,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziQuestionnaire.git",
       "state" : {
-        "revision" : "f25580e95bfdad02383980dcb94406cf97b08ea8",
-        "version" : "1.0.2"
+        "revision" : "f9d9b6d99bb1e00bda2974b440dca8367733d591",
+        "version" : "1.1.0"
       }
     },
     {
@@ -379,5 +380,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Intake/Home.swift
+++ b/Intake/Home.swift
@@ -130,7 +130,6 @@ struct HomeView: View {
                 case .general: PatientInfo()
                 }
             }
-            
         }
         .sheet(isPresented: $presentingAccount) {
             AccountSheet()

--- a/Intake/Home.swift
+++ b/Intake/Home.swift
@@ -29,7 +29,7 @@ struct StartButton: View {
     
     var body: some View {
         Button(action: {
-            navigationPath.append(NavigationViews.medical)
+            navigationPath.append(NavigationViews.chat)
         }) {
             Text("Start")
                 .font(.headline)
@@ -42,18 +42,10 @@ struct StartButton: View {
     }
 }
 
-struct HomeView: View {
-    static var accountEnabled: Bool {
-        !FeatureFlags.disableFirebase && !FeatureFlags.skipOnboarding
-    }
-
-    @State private var presentingAccount = false
-    @State private var showSettings = false
-
-    @Environment(NavigationPathWrapper.self) private var navigationPath
-    @Environment(DataStore.self) private var data
+struct SettingsButton: View {
+    @Binding var showSettings: Bool
     
-    private var SettingsButton: some View {
+    var body: some View {
         Button(
             action: {
                 showSettings.toggle()
@@ -68,8 +60,20 @@ struct HomeView: View {
             }
         )
     }
+}
+
+struct HomeView: View {
+    static var accountEnabled: Bool {
+        !FeatureFlags.disableFirebase && !FeatureFlags.skipOnboarding
+    }
+
+    @State private var presentingAccount = false
+    @State private var showSettings = false
+
+    @Environment(NavigationPathWrapper.self) private var navigationPath
+    @Environment(DataStore.self) private var data
     
-    private var HomeLogo: some View {
+    private var homeLogo: some View {
         Image(systemName: "waveform.path.ecg")
             .resizable()
             .aspectRatio(contentMode: .fit)
@@ -78,7 +82,7 @@ struct HomeView: View {
             .accessibilityLabel(Text("HOME_LOGO"))
     }
     
-    private var HomeTitle: some View {
+    private var homeTitle: some View {
         Group {
             Text("ReForm")
                 .font(.largeTitle)
@@ -97,13 +101,13 @@ struct HomeView: View {
         NavigationStack(path: $navigationPath.path) {
             VStack {
                 Spacer()
-                HomeLogo
-                HomeTitle
+                homeLogo
+                homeTitle
                 Spacer()
                 StartButton(navigationPath: $navigationPath.path)
                 
                 .toolbar {
-                    EditButton()
+                    SettingsButton(showSettings: $showSettings)
                 }
             }
 

--- a/Intake/Home.swift
+++ b/Intake/Home.swift
@@ -24,6 +24,24 @@ enum NavigationViews: String {
     case inspect
 }
 
+struct StartButton: View {
+    @Binding var navigationPath: NavigationPath
+    
+    var body: some View {
+        Button(action: {
+            navigationPath.append(NavigationViews.medical)
+        }) {
+            Text("Start")
+                .font(.headline)
+                .fontWeight(.bold)
+                .foregroundColor(.white)
+                .padding()
+                .background(Color.blue)
+                .cornerRadius(10)
+        }
+    }
+}
+
 struct HomeView: View {
     static var accountEnabled: Bool {
         !FeatureFlags.disableFirebase && !FeatureFlags.skipOnboarding
@@ -34,59 +52,58 @@ struct HomeView: View {
 
     @Environment(NavigationPathWrapper.self) private var navigationPath
     @Environment(DataStore.self) private var data
+    
+    private var SettingsButton: some View {
+        Button(
+            action: {
+                showSettings.toggle()
+            },
+            label: {
+                Image(systemName: "gear")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 30, height: 30)
+                    .foregroundColor(.blue)
+                    .accessibilityLabel(Text("SETTINGS"))
+            }
+        )
+    }
+    
+    private var HomeLogo: some View {
+        Image(systemName: "waveform.path.ecg")
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+            .frame(width: 100, height: 100)
+            .foregroundColor(.blue)
+            .accessibilityLabel(Text("HOME_LOGO"))
+    }
+    
+    private var HomeTitle: some View {
+        Group {
+            Text("ReForm")
+                .font(.largeTitle)
+                .fontWeight(.bold)
+                .foregroundColor(.black)
+            Text("AI-assisted medical intake")
+                .font(.title2)
+                .foregroundColor(.gray)
+        }
+    }
 
     var body: some View {
         @Bindable var navigationPath = navigationPath
         @Bindable var data = data
         
-        NavigationStack(path: $navigationPath.path) { // swiftlint:disable:this closure_body_length
-            VStack { // swiftlint:disable:this closure_body_length
-                HStack {
-                    Spacer()
-                    Button(
-                        action: {
-                            showSettings.toggle()
-                        },
-                        label: {
-                            Image(systemName: "gear")
-                                .resizable()
-                                .aspectRatio(contentMode: .fit)
-                                .frame(width: 30, height: 30)
-                                .foregroundColor(.blue)
-                                .accessibilityLabel(Text("SETTINGS"))
-                        }
-                    )
-                    .padding()
-                }
-
+        NavigationStack(path: $navigationPath.path) {
+            VStack {
                 Spacer()
-
-                Image(systemName: "waveform.path.ecg")
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(width: 100, height: 100)
-                    .foregroundColor(.blue)
-                    .accessibilityLabel(Text("HOME_LOGO"))
-                Text("ReForm")
-                    .font(.largeTitle)
-                    .fontWeight(.bold)
-                    .foregroundColor(.black)
-                Text("AI-assisted medical intake")
-                    .font(.title2)
-                    .foregroundColor(.gray)
-
+                HomeLogo
+                HomeTitle
                 Spacer()
-
-                Button(action: {
-                    navigationPath.path.append(NavigationViews.chat)
-                }) {
-                    Text("Start")
-                        .font(.headline)
-                        .fontWeight(.bold)
-                        .foregroundColor(.white)
-                        .padding()
-                        .background(Color.blue)
-                        .cornerRadius(10)
+                StartButton(navigationPath: $navigationPath.path)
+                
+                .toolbar {
+                    EditButton()
                 }
             }
 

--- a/Intake/IntakeDelegate.swift
+++ b/Intake/IntakeDelegate.swift
@@ -71,21 +71,12 @@ class IntakeDelegate: SpeziAppDelegate {
         )
     }
 
-    // swiftlint:disable trailing_newline
     private var healthKit: HealthKit {
         HealthKit {
             CollectSample(
                 HKQuantityType(.stepCount),
-                deliverySetting: .anchorQuery(.afterAuthorizationAndApplicationWillLaunch)
+                deliverySetting: .anchorQuery(.automatic)
             )
-            /*
-            CollectSample(
-                HKCharacteristicType(.biologicalSex),
-                deliverySetting: .anchorQuery(saveAnchor: false)
-            )
-             */
         }
     }
 }
-// swiftlint:enable trailing newline
-

--- a/Intake/Resources/Localizable.xcstrings
+++ b/Intake/Resources/Localizable.xcstrings
@@ -246,10 +246,10 @@
     "Date of Birth:" : {
 
     },
-    "Delete" : {
-    
-    },
     "Date:" : {
+
+    },
+    "Delete" : {
 
     },
     "DELETE_REACTION" : {
@@ -286,9 +286,6 @@
 
     },
     "FHIR_RESOURCES_CHAT_CANCEL" : {
-
-    },
-    "fix medication" : {
 
     },
     "Full name" : {

--- a/Intake/Resources/Localizable.xcstrings
+++ b/Intake/Resources/Localizable.xcstrings
@@ -218,7 +218,13 @@
     "Date of Birth:" : {
 
     },
+    "Delete" : {
+
+    },
     "DELETE_REACTION" : {
+
+    },
+    "DELETE_SURGERY" : {
 
     },
     "DETAILS" : {
@@ -613,6 +619,9 @@
           }
         }
       }
+    },
+    "Select + to add a surgery" : {
+
     },
     "SETTINGS" : {
 

--- a/Intake/Surgery/SurgeryView.swift
+++ b/Intake/Surgery/SurgeryView.swift
@@ -313,7 +313,7 @@ struct SurgeryView: View {
         let LLMResponse = try await self.queryLLM(surgeryNames: surgeryNames)
         
         let filteredNames = LLMResponse.components(separatedBy: ", ")
-        var filteredSurgeries = surgeries.filter { self.containsAnyWords(item: $0.surgeryName, words: filteredNames) }
+        let filteredSurgeries = surgeries.filter { self.containsAnyWords(item: $0.surgeryName, words: filteredNames) }
         
         return self.cleanSurgeryNames(surgeries: filteredSurgeries, filteredNames: filteredNames)
     }

--- a/Intake/Surgery/SurgeryView.swift
+++ b/Intake/Surgery/SurgeryView.swift
@@ -94,12 +94,12 @@ struct SurgeryView: View {
             }
             .navigationTitle("Surgical History")
             .navigationBarItems(trailing: AddSurgery(surgeries: $data.surgeries))
-//             .navigationBarItems(trailing: NavigationLink(destination: SurgeryLLMAssistant(presentingAccount: .constant(false))) {
-//                 Text("Chat")
-//             })
-            .toolbar {
-                EditButton()
-            }
+             .navigationBarItems(trailing: NavigationLink(destination: SurgeryLLMAssistant(presentingAccount: .constant(false))) {
+                 Text("Chat")
+             })
+//            .toolbar {
+//                EditButton()
+//            }
         } else {
             ProgressView()
                 .task {

--- a/Intake/Surgery/SurgeryView.swift
+++ b/Intake/Surgery/SurgeryView.swift
@@ -49,6 +49,9 @@ struct AddSurgery: View {
 
 struct InspectSurgeryView: View {
     @Binding var surgery: SurgeryItem
+    @Environment(DataStore.self) var data
+    @Environment(NavigationPathWrapper.self) var navigationPath
+    @Environment(\.dismiss) private var dismiss
     
     var isNew: Bool
     
@@ -71,6 +74,23 @@ struct InspectSurgeryView: View {
             }
         }
         .navigationBarTitle(isNew ? "New Surgery" : "Edit Surgery")
+        .navigationBarItems(trailing: !isNew ? deleteButton : nil)
+    }
+    
+    private var deleteButton: some View {
+        Button(action: {
+            if let index = data.surgeries.firstIndex(of: surgery) {
+                data.surgeries.remove(at: index)
+            }
+            dismiss()
+        }) {
+            Text("Delete")
+                .font(.headline)
+                .foregroundColor(.blue)
+                .padding(8) // Add padding
+                .cornerRadius(8) // Round the corners
+                .accessibilityLabel(Text("DELETE_SURGERY"))
+        }
     }
 }
 
@@ -94,12 +114,9 @@ struct SurgeryView: View {
             }
             .navigationTitle("Surgical History")
             .navigationBarItems(trailing: AddSurgery(surgeries: $data.surgeries))
-             .navigationBarItems(trailing: NavigationLink(destination: SurgeryLLMAssistant(presentingAccount: .constant(false))) {
+            .navigationBarItems(trailing: NavigationLink(destination: SurgeryLLMAssistant(presentingAccount: .constant(false))) {
                  Text("Chat")
-             })
-//            .toolbar {
-//                EditButton()
-//            }
+            })
         } else {
             ProgressView()
                 .task {
@@ -125,7 +142,11 @@ struct SurgeryView: View {
         Form {
             @Bindable var data = data
             Section(header: Text("Please add your past surgeries")) {
-                surgeryElements
+                if data.surgeries.isEmpty {
+                    Text("Select + to add a surgery")
+                } else {
+                    surgeryElements
+                }
             }
         }
     }


### PR DESCRIPTION
# Finalize SurgeryView UI and refactor HomeView

## :recycle: Current situation & Problem
The SurgeryView previously did not have room for the "chat" button in the toolbar to bring up the LLM chat assistant. Also, the HomeView code was extremely messy and used disable swiftlint commands to avoid warnings.

## :gear: Release Notes 
Got rid of the "edit" button in SurgeryView. Added a "delete" button to the InspectSurgeryView (it is not shown when adding a new surgery). Now, if a user wants to delete a surgery, they can either swipe left on the surgery in SurgeryView or click on it to edit and select the "delete" button. SurgeryView now has a "chat" button in the toolbar to activate the LLM assistant.

## :books: Documentation
This is what the new views look like:
<img width="327" alt="Screenshot 2024-03-11 at 12 01 06 AM" src="https://github.com/CS342/2024-Intake/assets/108841122/8b91723d-96bb-4aee-be94-9b34337458ab">
<img width="323" alt="Screenshot 2024-03-11 at 12 00 39 AM" src="https://github.com/CS342/2024-Intake/assets/108841122/863224df-69f2-4b41-b70d-028d135ac4d4">
<img width="322" alt="Screenshot 2024-03-11 at 12 00 55 AM" src="https://github.com/CS342/2024-Intake/assets/108841122/cfdec751-66a7-467a-8ef0-50375429ef6e">


## :white_check_mark: Testing
This code will be thoroughly tested along with the rest of the codebase.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).
