### PR TITLE
Dismiss LLM onboarding view if token is already present

### DIFF
--- a/Intake/ChiefComplaint/LLMAssistantView.swift
+++ b/Intake/ChiefComplaint/LLMAssistantView.swift
@@ -26,6 +26,7 @@ struct LLMAssistantView: View {
     @Binding var initialQuestion: String
     @Binding var prompt: String
     @LLMSessionProvider<LLMOpenAISchema> var session: LLMOpenAISession
+    @Environment(LLMOpenAITokenSaver.self) private var tokenSaver
 
     var body: some View {
         NavigationView {
@@ -41,7 +42,9 @@ struct LLMAssistantView: View {
                     AccountButton(isPresented: $presentingAccount)
                 }
             }
-            .onAppear {
+            .task {
+                showOnboarding = !tokenSaver.tokenPresent
+                
                 if greeting {
                     let assistantMessage = ChatEntity(role: .assistant, content: initialQuestion)
                     session.context.insert(assistantMessage, at: 0)


### PR DESCRIPTION
# Dismiss LLM onboarding view if token is already present

## :recycle: Current situation & Problem
Currently, the LLM onboarding view is shown for every LLM interaction, even when the token is present.


## :gear: Release Notes 
- Dismiss LLM onboarding view if token is already present


## :books: Documentation
--


## :white_check_mark: Testing
No testing occurred, responsibility of @nriedman 


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).
