### PR TITLE
Hard code Token onboarding for Chief Complaint

### DIFF
--- a/Intake.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Intake.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "cdbe60a3382a8a962c7fcc00210e56e13314cb3e246d0e01fe8e25a1268623d8",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -379,5 +380,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Intake/ChiefComplaint/LLMInteraction.swift
+++ b/Intake/ChiefComplaint/LLMInteraction.swift
@@ -101,8 +101,6 @@ struct LLMInteraction: View {
         }
         
         .onAppear {
-            checkToken()
-            
             let nameString = data.generalData.name.components(separatedBy: " ")
             if let firstNameValue = nameString.first {
                 firstName = firstNameValue


### PR DESCRIPTION
# Debug token onboarding

## :recycle: Current situation & Problem
There is no way to change the token once you provide it.


## :gear: Release Notes 
- Patched the issue by hard-coding the token onboarding to appear every time the Primary Concern view is opened.


## :books: Documentation
NA


## :white_check_mark: Testing
NA


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).
