### PR TITLE
Remove Firebase beta deployment release job

### DIFF
--- a/.github/workflows/beta-deployment.yml
+++ b/.github/workflows/beta-deployment.yml
@@ -31,11 +31,3 @@ jobs:
       googleserviceinfoplistpath: 'Intake/Supporting Files/GoogleService-Info.plist'
       setupsigning: true
       fastlanelane: beta
-  deployfirebase:
-    name: Deploy Firebase Project
-    needs: iosapptestflightdeployment
-    uses: StanfordBDHG/.github/.github/workflows/firebase-deploy.yml@v2
-    with:
-      arguments: '--debug'
-    secrets:
-      GOOGLE_APPLICATION_CREDENTIALS_BASE64: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_BASE64 }}


### PR DESCRIPTION
# Remove firebase beta deployment

## :recycle: Current situation & Problem
As of now, the release pipeline fails as no Firebase project file is present anymore in the project. However, the Firebase deployment step is not required, we can remove this release job all together.


## :gear: Release Notes 
- Remove Firebase beta deployment release job


## :books: Documentation
--


## :white_check_mark: Testing
--


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).
